### PR TITLE
Use pyomnisense >= 0.2.0; stop closing session every poll

### DIFF
--- a/custom_components/omnisense/__init__.py
+++ b/custom_components/omnisense/__init__.py
@@ -32,6 +32,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+        coordinator = hass.data[DOMAIN].pop("coordinator", None)
+        if coordinator is not None and getattr(coordinator, "omnisense", None) is not None:
+            try:
+                await coordinator.omnisense.close()
+            except Exception as err:  # pragma: no cover - best-effort cleanup
+                _LOGGER.warning("Error closing Omnisense session on unload: %s", err)
 
     return unload_ok

--- a/custom_components/omnisense/config_flow.py
+++ b/custom_components/omnisense/config_flow.py
@@ -6,7 +6,7 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from .const import CONF_SELECTED_SITES, CONF_SELECTED_SENSORS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.selector import SelectSelector
-from pyomnisense import Omnisense
+from pyomnisense import Omnisense, OmnisenseAuthError, OmnisenseError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,23 +26,30 @@ class OmnisenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.username = user_input.get(CONF_USERNAME)
             self.password = user_input.get(CONF_PASSWORD)
 
+            login_ok = False
             try:
-                 await self.omnisense.login(self.username, self.password)
-            except Exception as err:  # or a more specific exception if known
-                _LOGGER.error("Failed to create Omnisense instance: %s", err)
+                login_ok = await self.omnisense.login(self.username, self.password)
+            except OmnisenseAuthError as err:
+                _LOGGER.error("Omnisense login rejected: %s", err)
                 errors["base"] = "omnisense_login_failed"
-   
-            # Validate credentials and fetch available sites
-            try:
-                sites = await self.omnisense.get_site_list()
-                if sites:
-                    self.available_sites = sites
-                    return await self.async_step_select_site()
-                else:
-                    errors["base"] = "no_sites_found"
-            except Exception as err:  # or a more specific exception if known
-                _LOGGER.error("Error fetching site list: %s", err)
-                errors["base"] = "failed_to_get_sites"
+            except OmnisenseError as err:
+                _LOGGER.error("Omnisense login failed: %s", err)
+                errors["base"] = "omnisense_login_failed"
+
+            if not errors and not login_ok:
+                errors["base"] = "omnisense_login_failed"
+
+            if not errors:
+                try:
+                    sites = await self.omnisense.get_site_list()
+                    if sites:
+                        self.available_sites = sites
+                        return await self.async_step_select_site()
+                    else:
+                        errors["base"] = "no_sites_found"
+                except OmnisenseError as err:
+                    _LOGGER.error("Error fetching site list: %s", err)
+                    errors["base"] = "failed_to_get_sites"
 
         schema = vol.Schema({
             vol.Required(CONF_USERNAME): str,

--- a/custom_components/omnisense/manifest.json
+++ b/custom_components/omnisense/manifest.json
@@ -14,7 +14,7 @@
     "voluptuous",
     "numpy",
     "scipy",
-    "pyomnisense>=0.1.2"
+    "pyomnisense>=0.2.0"
   ],
-  "version": "0.1.12"
+  "version": "0.1.13"
 }

--- a/custom_components/omnisense/sensor.py
+++ b/custom_components/omnisense/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.core import callback
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from .const import CONF_SELECTED_SITES, CONF_SELECTED_SENSORS
 
-from pyomnisense import Omnisense
+from pyomnisense import Omnisense, OmnisenseAuthError, OmnisenseError
 
 from .const import DOMAIN
 
@@ -73,11 +73,13 @@ class OmniSenseCoordinator(DataUpdateCoordinator):
 
         try:
             success = await self.omnisense.login(self.username, self.password)
-            await self.omnisense.close() 
-        except Exception as err:
-            _LOGGER.error("Failed to login to omnisense: %s", err)
-            raise UpdateFailed("Failed to create Omnisense instance")
-        
+        except OmnisenseAuthError as err:
+            _LOGGER.error("Omnisense login rejected: %s", err)
+            raise UpdateFailed("Failed to login to Omnisense with provided credentials")
+        except OmnisenseError as err:
+            _LOGGER.error("Omnisense login failed: %s", err)
+            raise UpdateFailed(f"Failed to login to Omnisense: {err}")
+
         if not success:
             _LOGGER.error("Failed to login to omnisense with provided credentials")
             raise UpdateFailed("Failed to login to Omnisense with provided credentials")
@@ -99,18 +101,17 @@ class OmniSenseCoordinator(DataUpdateCoordinator):
         # Note: asyncio.TimeoutError and aiohttp.ClientError are already
         # handled by the data update coordinator.
         _LOGGER.debug(f"Fetching new sensor data")
-        # async with async_timeout.timeout(10):
-        #     return await _fetch_sensor_data(self.username, self.password, self.sites, self.sensor_ids)
-        async with async_timeout.timeout(10):
+        async with async_timeout.timeout(30):
             try:
-                data =  await self.omnisense.get_sensor_data(self.sites, self.sensor_ids)
+                data = await self.omnisense.get_sensor_data(self.sites, self.sensor_ids)
                 _LOGGER.debug(f"Fetched sensor data: {data}")
-            except Exception as err:
+            except OmnisenseAuthError as err:
+                _LOGGER.error("Omnisense authentication failed during fetch: %s", err)
+                raise UpdateFailed(f"Authentication failed: {err}")
+            except OmnisenseError as err:
                 _LOGGER.error("Error fetching sensor data: %s", err)
                 raise UpdateFailed(f"Error fetching sensor data: {err}")
-            finally:
-                await self.omnisense.close()  # Always close the session 
-                           
+
             return data
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ homeassistant
 python-dotenv
 Requests
 voluptuous
-pyomnisense
+pyomnisense>=0.2.0


### PR DESCRIPTION
## Why

[`pyomnisense` 0.2.0](https://github.com/sslivins/pyomnisense/releases/tag/v0.2.0) finally lands real session reuse, transparent re-login on session expiry, and typed exceptions. This integration was actively *defeating* the first one by calling `await self.omnisense.close()` after the initial login **and** inside the `finally:` block of every 15-minute coordinator poll. So every poll was paying for a fresh login + cookie round-trip even though the new pyomnisense is perfectly happy to reuse the existing session.

## What

### `manifest.json` + `requirements.txt`
- Pin `pyomnisense>=0.2.0`.
- Bump integration version `0.1.12` → `0.1.13`.

### `custom_components/omnisense/sensor.py`
- **Drop the `close()` after login** in `_async_setup`.
- **Drop the `finally: await self.omnisense.close()` in every poll** — this was the main bug; it ran every 15 min and forced a full re-login on the next tick.
- Catch the new typed exceptions (`OmnisenseAuthError` / `OmnisenseError`) instead of bare `Exception`.
- Bump the per-poll `async_timeout` from 10s → 30s. Because pyomnisense can now do transparent re-login inside a single `get_sensor_data` call (up to ~3 HTTP round-trips), 10s was tight on slow networks.

### `custom_components/omnisense/config_flow.py`
- Fix a fall-through bug: when `login()` raised, the old code recorded the error and *still* called `get_site_list()` against the broken session. Now the flow short-circuits and re-renders the credentials form.
- Also treat `login() -> False` as a credential failure (server returns `userPNSToken=login+failed` for bad creds).
- Typed exceptions instead of bare `Exception`.

### `custom_components/omnisense/__init__.py`
- `async_unload_entry` now `await coordinator.omnisense.close()`s the session before popping the data, instead of leaking the aiohttp `ClientSession` on integration reload.

## Out of scope (worth a follow-up)

- `sensor.py:251` hardcodes `ZoneInfo('America/Los_Angeles')` for the `last_activity` timestamps. Should use `hass.config.time_zone`.
- `tests.py` at the repo root references an `OmniSenseSensor` class that no longer exists — it's a stale dev script.
- The coordinator is stored at `hass.data[DOMAIN]['coordinator']` (singleton) rather than `hass.data[DOMAIN][entry.entry_id]`, so the integration can't really support multiple config entries today.